### PR TITLE
add hadoop user to base accumulo image

### DIFF
--- a/prod/base/Dockerfile
+++ b/prod/base/Dockerfile
@@ -30,3 +30,5 @@ RUN set -x && \
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 ENV PATH $PATH:$JAVA_HOME/bin
+
+RUN useradd -ms /bin/bash hadoop


### PR DESCRIPTION
What I am finding is that when working on HDFS instance that has permissions enabled, like EMR, it's important to be the correct user. Currently if you were to try to `accumulo init` on EMR you would get something like:

```
Caused by: org.apache.hadoop.ipc.RemoteException(org.apache.hadoop.security.AccessControlException): Permission denied: user=root, access=WRITE, inode="/accumulo/version/7":hdfs:hadoop:drwxr-xr-x
```

Weirdly the user in question is not the owner of the container process but the user inside the container. Adding this user so one can:

```
docker run --rm -u hadoop ....
```

solves the issue.

Is there a more graceful way to handle this case? While hadoop is the only user, its probably not the only possible option in the wild.
