### PR TITLE
Run processes as hadoop user

### DIFF
--- a/prod/accumulo/base/Dockerfile
+++ b/prod/accumulo/base/Dockerfile
@@ -10,12 +10,15 @@ ENV ACCUMULO_HOME /opt/accumulo
 ENV ACCUMULO_CONF_DIR $ACCUMULO_HOME/conf
 ENV PATH $PATH:$ACCUMULO_HOME/bin
 
+USER root
 RUN set -x && \
     mkdir -p ${ACCUMULO_HOME} ${ACCUMULO_CONF_DIR} && \
     curl -# http://apache-mirror.rbc.ru/pub/apache/accumulo/${ACCUMULO_VERSION}/accumulo-${ACCUMULO_VERSION}-bin.tar.gz | tar -xz -C ${ACCUMULO_HOME} --strip-components=1 && \
     cp ${ACCUMULO_HOME}/conf/examples/3GB/standalone/* ${ACCUMULO_CONF_DIR}/
 
 COPY ./fs /
+RUN chown -R hadoop:hadoop $ACCUMULO_HOME
+USER hadoop
 
 # Geo Iterators
 RUN sbin/load-iterators.sh

--- a/prod/accumulo/base/Dockerfile
+++ b/prod/accumulo/base/Dockerfile
@@ -21,7 +21,7 @@ RUN chown -R hadoop:hadoop $ACCUMULO_HOME
 USER hadoop
 
 # Geo Iterators
-RUN sbin/load-iterators.sh
+RUN /sbin/load-iterators.sh
 
 WORKDIR "${ACCUMULO_HOME}"
 ENTRYPOINT [ "/sbin/entrypoint.sh" ]

--- a/prod/base/centos.dockerfile
+++ b/prod/base/centos.dockerfile
@@ -27,4 +27,4 @@ RUN wget -O /tmp/maven.tar.gz http://mirrors.gigenet.com/apache/maven/maven-3/3.
 RUN tar -xvf /tmp/maven.tar.gz -C /usr/local/
 RUN cd /usr/local && ln -s apache-maven-3.3.9 maven
 
-
+RUN useradd -ms /bin/bash hadoop

--- a/prod/hadoop/base/Dockerfile
+++ b/prod/hadoop/base/Dockerfile
@@ -13,6 +13,11 @@ RUN set -x && \
     curl -# http://apache-mirror.rbc.ru/pub/apache/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz | tar -xz -C ${HADOOP_PREFIX} --strip-components=1    
 
 COPY ./fs /
+RUN chown -R hadoop:hadoop $HADOOP_PREFIX
+
+USER hadoop
+ENV USER hadoop
+ENV HOME /user/hadoop
 
 WORKDIR "${HADOOP_HOME}"
 ENTRYPOINT [ "/sbin/entrypoint.sh" ]


### PR DESCRIPTION
Runs the processes inside the container as hadoop user.

My selfish reasons is to have this work seamlessly with EMR, however it appears to be good practice to run the container process as non-root user when possible. In this case it's possible so double bonus.
